### PR TITLE
feat: Adiciona página DiarioDeTrade com modal para novas anotações

### DIFF
--- a/src/pages/DiarioDeTrade.jsx
+++ b/src/pages/DiarioDeTrade.jsx
@@ -1,10 +1,25 @@
+import { useState } from 'react';
 import DiarioHeader from '../components/DiariodeTrade/DiarioHeader';
+import ModalNotas from '../components/DiariodeTrade/modals/ModalNotas';
+
 
 function DiarioDeTradePage() {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
   return (
-    <div>
+    <>
       <DiarioHeader />
-    </div>
+      
+      <main style={{ padding: '20px' }}>
+        <h2>Minhas Anotações</h2>
+        <button onClick={() => setIsModalOpen(true)}>Adicionar Nova Anotação</button>
+      </main>
+
+      <ModalNotas 
+        isOpen={isModalOpen} 
+        onClose={() => setIsModalOpen(false)} 
+      />
+    </>
   );
 }
 


### PR DESCRIPTION
Este commit introduz a nova página DiarioDeTrade, que permite aos usuários visualizar suas anotações de trade. Inclui um botão para abrir um modal para adicionar novas anotações.